### PR TITLE
Add support for two way communication remote access and fix a few bugs.

### DIFF
--- a/common/TimeoutMap.lua
+++ b/common/TimeoutMap.lua
@@ -1,0 +1,36 @@
+---A map that removes entries once they expire
+---@class (exact) TimeoutMap
+---@field entries {}
+---@field private expireCheckCallback fun(key:any, value: any): boolean
+---@field __index TimeoutMap
+local TimeoutMap = {}
+TimeoutMap.__index = TimeoutMap
+
+---@param expireCheckCallback fun(key:any, value: any): boolean
+---@return TimeoutMap
+function TimeoutMap:new(expireCheckCallback)
+    local newMap = {}
+    newMap.expireCheckCallback = expireCheckCallback
+    newMap.entries = {}
+    setmetatable(newMap, TimeoutMap)
+
+    return newMap
+end
+function TimeoutMap:set(key, value)
+    self.entries[key] = value
+end
+function TimeoutMap:contains(key)
+    if self.entries[key] then
+        return true
+    end
+    return false
+end
+function TimeoutMap:cull()
+    for k,v in pairs(self.entries) do
+        if self.expireCheckCallback(k,v) then
+            self.entries[k] = nil
+        end
+    end
+end
+
+return TimeoutMap

--- a/common/startup.lua
+++ b/common/startup.lua
@@ -72,7 +72,7 @@ else
                 else
                     if machineConfig.isProduction then
                         ---@type TraceReport
-                        local trace = {type="trace", computer=os.getComputerID(), isStartup = true, timestamp=os.time("utc"), traceback = filter}
+                        local trace = {type="trace", computer=os.getComputerID(), isStartup = true, timestamp=os.epoch("utc"), traceback = filter}
                         rednet.send(machineConfig.errorReportingServiceId, trace, "errorReporting")
                         os.reboot()
                     else
@@ -82,7 +82,7 @@ else
                 if coroutine.status(startupRoutine) == "dead" then
                     if machineConfig.isProduction then
                         ---@type EndedReport
-                        local trace = {type="programEnded", computer=os.getComputerID(), timestamp=os.time("utc")}
+                        local trace = {type="programEnded", computer=os.getComputerID(), timestamp=os.epoch("utc")}
                         rednet.send(machineConfig.errorReportingServiceId, trace, "errorReporting")
                         os.reboot()
                     else
@@ -103,6 +103,8 @@ else
                         saveMachineConfig()
                     elseif message.type == "reboot" then
                         os.reboot()
+                    elseif message.type == "getMachineConfig" and type(message.forId) == "number" and type(message.forUser) == "string" then
+                        rednet.send(sender, {type="machineConfig",value=machineConfig, forId = message.forId, forUser = message.forUser}, "remoteManagement")
                     end
                 end
             end
@@ -114,5 +116,3 @@ else
         parallel.waitForAny(doStartupThread)
     end
 end
-
-window.create()

--- a/services/RedNAT/RedNAT.lua
+++ b/services/RedNAT/RedNAT.lua
@@ -1,0 +1,208 @@
+--Allows ingress and egress of permitted protocols from a network. 
+--works kinda like real nat. Basically the way it works is
+--rednet.send(rednatServerId + interalId*rednet.MAX_ID_CHANNELS, message).
+
+local externalSide = "bottom"
+local internalSide = "top"
+
+---Modem with untrusted traffic
+local ExternalModem = peripheral.wrap(externalSide)
+---Modem with trusted traffic
+local InternalModem = peripheral.wrap(internalSide)
+
+if not ExternalModem or peripheral.getType(ExternalModem) ~= "modem" then
+    error("Unable to find external modem")
+end
+if not InternalModem or peripheral.getType(InternalModem) ~= "modem" then
+    error("Unable to find interior modem")
+end
+
+---@cast ExternalModem Modem
+---@cast InternalModem Modem
+
+---@type {allowedProtocols:string[], allowedComputers:string[], byId:table<number, string[]>}
+local ingress = {byId={},allowedComputers={},allowedProtocols={}}
+---@type {allowedProtocols:string[], allowedComputers:string[], byId:table<number, string[]>}
+local egress = {byId={},allowedComputers={},allowedProtocols={}}
+
+do
+    local rh = fs.open("/ingress.cnf", "r")
+    if not rh then
+        error("unable to load ingress config")
+    end
+    local data = rh.readAll()
+    rh.close()
+    if not data then
+        error("unable to read ingress config")
+    end
+    local parsed = textutils.unserialise(data)
+    if type(parsed) ~= "table" or type(parsed.allowedComputers) ~= "table" or type(parsed.allowedProtocols) ~= "table" or type(parsed.byId) ~= "table" then
+        error("ingress config is invalid")
+    end
+    for k,v in ipairs(parsed.allowedProtocols) do
+        if type(v) == "string" and type(k) == "number" then
+            table.insert(ingress.allowedProtocols,v)
+        end
+    end
+    for k,v in ipairs(parsed.allowedComputers) do
+        if type(v) == "string" and type(k) == "number" then
+            table.insert(ingress.allowedComputers,v)
+        end
+    end
+    for k,v in pairs(parsed.byId) do
+        if type(k) == "number" and type(v) == "table" then
+            local sanitized = {}
+            for i, protocol in ipairs(v) do
+                if type(i) == "number" and type(protocol) == "string" then
+                    table.insert(sanitized, protocol)
+                end
+            end
+            ingress.byId[k] = sanitized
+        end
+    end
+end
+
+do
+    local rh = fs.open("/egress.cnf", "r")
+    if not rh then
+        error("unable to load egress config")
+    end
+    local data = rh.readAll()
+    rh.close()
+    if not data then
+        error("unable to read egress config")
+    end
+    local parsed = textutils.unserialise(data)
+    if type(parsed) ~= "table" or type(parsed.allowedComputers) ~= "table" or type(parsed.allowedProtocols) ~= "table" or type(parsed.byId) ~= "table" then
+        error("egress config is invalid")
+    end
+    for k,v in ipairs(parsed.allowedProtocols) do
+        if type(v) == "string" and type(k) == "number" then
+            table.insert(egress.allowedProtocols,v)
+        end
+    end
+    for k,v in ipairs(parsed.allowedComputers) do
+        if type(v) == "string" and type(k) == "number" then
+            table.insert(egress.allowedComputers,v)
+        end
+    end
+    for k,v in pairs(parsed.byId) do
+        if type(k) == "number" and type(v) == "table" then
+            local sanitized = {}
+            for i, protocol in ipairs(v) do
+                if type(i) == "number" and type(protocol) == "string" then
+                    table.insert(sanitized, protocol)
+                end
+            end
+            egress.byId[k] = sanitized
+        end
+    end
+end
+
+ExternalModem.open(os.getComputerID())
+InternalModem.open(os.getComputerID())
+
+local allowedFields = {nMessageID=true,nSender=true,nRecipient=true,sHostname=true,sType=true,message=true,sProtocol=true}
+
+while true do
+    local event, side, channel, reply, message, dist = os.pullEvent("modem_message")
+    if side == externalSide then
+        if type(message) == "table" and type(message.nMessageID) == "number" and
+            type(message.nSender) == "number" and type(message.nRecipient) == "number" and
+            message.nRecipient%rednet.MAX_ID_CHANNELS == os.getComputerID() and
+            (not message.sProtocol or type(message.sProtocol) == "string") then
+            local continue = true
+            for k,v in pairs(message) do
+                if not allowedFields[k] then
+                    continue = false
+                    break
+                end
+            end
+            ---@cast message {nSender: number, nRecipient:number, sHostname: string|nil, sProtocol:string|nil, message: any, sType: string|nil, nMessageID: number}
+            if continue then
+                local internalId = (message.nRecipient - os.getComputerID())/rednet.MAX_ID_CHANNELS
+                if internalId >= 0 and internalId <= rednet.MAX_ID_CHANNELS then
+                    local permitted = false
+                    for index, value in ipairs(ingress.allowedComputers) do
+                        if value == internalId then
+                            permitted = true
+                        end
+                    end
+                    for index, value in ipairs(ingress.allowedProtocols) do
+                        if value == message.sProtocol then
+                            permitted = true
+                        end
+                    end
+                    local allowedProts = ingress.byId[internalId]
+                    if allowedProts then
+                        for k, prot in ipairs(allowedProts) do
+                            if prot == message.sProtocol then
+                                permitted = true
+                            end
+                        end 
+                    end
+                    if permitted then
+                        InternalModem.transmit(internalId%rednet.MAX_ID_CHANNELS, os.getComputerID(), {
+                            nMessageID = message.nMessageID,
+                            nSender = os.getComputerID() + message.nSender * rednet.MAX_ID_CHANNELS,
+                            nRecipient = internalId,
+                            sHostname = message.sHostname,
+                            sProtocol = message.sProtocol,
+                            sType = message.sType,
+                            message = message.message
+                        })
+                    end
+                end
+            end
+        end
+    elseif side == internalSide then
+        if type(message) == "table" and type(message.nMessageID) == "number" and
+            type(message.nSender) == "number" and type(message.nRecipient) == "number" and
+            message.nRecipient%rednet.MAX_ID_CHANNELS == os.getComputerID() and
+            (not message.sProtocol or type(message.sProtocol) == "string") then
+            local continue = true
+            for k,v in pairs(message) do
+                if not allowedFields[k] then
+                    continue = false
+                    break
+                end
+            end
+            ---@cast message {nSender: number, nRecipient:number, sHostname: string|nil, sProtocol:string|nil, message: any, sType: string|nil, nMessageID: number}
+            if continue then
+                local externalId = (message.nRecipient - os.getComputerID())/rednet.MAX_ID_CHANNELS
+                if externalId >= 0 and externalId <= rednet.MAX_ID_CHANNELS then
+                    local permitted = false
+                    for index, value in ipairs(egress.allowedComputers) do
+                        if value == externalId then
+                            permitted = true
+                        end
+                    end
+                    for index, value in ipairs(egress.allowedProtocols) do
+                        if value == message.sProtocol then
+                            permitted = true
+                        end
+                    end
+                    local allowedProts = egress.byId[externalId]
+                    if allowedProts then
+                        for k, prot in ipairs(allowedProts) do
+                            if prot == message.sProtocol then
+                                permitted = true
+                            end
+                        end 
+                    end
+                    if permitted then
+                        ExternalModem.transmit(externalId%rednet.MAX_ID_CHANNELS, os.getComputerID(), {
+                            nMessageID = message.nMessageID,
+                            nSender = os.getComputerID() + message.nSender * rednet.MAX_ID_CHANNELS,
+                            nRecipient = externalId,
+                            sHostname = message.sHostname,
+                            sProtocol = message.sProtocol,
+                            sType = message.sType,
+                            message = message.message
+                        })
+                    end
+                end
+            end
+        end
+    end
+end

--- a/services/RemoteManagementService/RemoteManagementService.lua
+++ b/services/RemoteManagementService/RemoteManagementService.lua
@@ -1,4 +1,6 @@
 local aead = require("ccryptolib.aead")
+local TimeoutMap = require("TimeoutMap")
+local random     = require("ccryptolib.random")
 local len = string.len
 
 ---@type table<string, string>
@@ -18,24 +20,41 @@ do
     end
 end
 
-rednet.open("bottom")
+rednet.open("top")
 rednet.host("arcadeRemoteManagement", "arcadeRemoteManagementService")
+rednet.host("remoteManagement", "remoteManagementService")
 
----@type Modem
-local modem = peripheral.wrap("top")
 local selfId = os.getComputerID()
 
----FIXME: add logic to remove old nonces from this list
-local nonces = {}
+random.initWithTiming()
 
-local function sendMessageToComputer(id, message, protocol)
-    modem.transmit(id, os.getComputerID(), {sProtocol=protocol,nSender=os.getComputerID(),nRecipient=id,nMessageID=math.random(1, 2147483647),message = message})
+local function sendMessage(id, user, message)
+    local key = keys[user]
+    if key then
+        local nonce = random.random(12)
+        local ciphertext, tag = aead.encrypt(key, nonce, textutils.serialise(message, { compact = true }), user..":frommanagement", 20)
+        rednet.send(id, { nonce = nonce, ciphertext = ciphertext, tag = tag, user = user },
+            "arcadeRemoteManagement")
+    end
 end
 
+local function sendMessageToPocket(id, user, message)
+    sendMessage(id, user, { m = message, ts = os.epoch("utc") })
+end
+
+
+local function sendMachineConfig(id, user, computerId, value)
+    sendMessageToPocket(id, user, { type = "machineConfig", id=computerId, value = value })
+end
+
+local nonces = TimeoutMap:new(function (key,value)
+    return value + 2000 < os.epoch("utc")
+end)
+
 while true do
-    local sender, message, protocol = rednet.receive("arcadeRemoteManagement")
-    if type(message) == "table" then
-        if type(message.ciphertext) == "string" and type(message.tag) == "string" and len(message.tag) == 16 and type(message.nonce) == "string" and len(message.nonce) == 12 and type(message.user) == "string" and keys[message.user] and not nonces[message.nonce] then
+    local sender, message, protocol = rednet.receive(nil,0.05)
+    if type(message) == "table"then
+        if protocol == "arcadeRemoteManagement" and type(message.ciphertext) == "string" and type(message.tag) == "string" and len(message.tag) == 16 and type(message.nonce) == "string" and len(message.nonce) == 12 and type(message.user) == "string" and keys[message.user] and not nonces:contains(message.nonce) then
             local key = keys[message.user]
 
             local plaintext = aead.decrypt(key, message.nonce, message.tag, message.ciphertext, message.user, 20)
@@ -45,14 +64,20 @@ while true do
                     if type(decoded) == "table" and type(decoded.ts) == "number" then
                         local now = os.epoch("utc")
                         if decoded.ts > now - 1000 and decoded.ts < now + 500 then
-                            nonces[message.nonce] = decoded.ts
-                            if decoded.t == "c" and type(decoded.i) == "number" and decoded.m ~= nil then
-                                sendMessageToComputer(decoded.i, decoded.m, "remoteManagement")
+                            nonces:set(message.nonce, decoded.ts)
+                            if decoded.t == "c" and type(decoded.i) == "number" and type(decoded.m) == "table" then
+                                decoded.m.forId = sender
+                                rednet.send(decoded.i, decoded.m, "remoteManagement")
                             end
                         end
                     end
                 end
             end
+        elseif protocol == "remoteManagement" then
+            if message.type == "machineConfig" and type(message.forUser) == "string" and type(message.forId) == "number" and type(message.value) == "table" then
+                sendMachineConfig(message.forId, message.forUser, sender, message.value)
+            end
         end
     end
+    nonces:cull()
 end


### PR DESCRIPTION
RedNAT allows for exposing multiple computers over one computer and controlling the allowed protocols. This works by exploiting the rednet channel limit. It isn't perfectly transparent if any computer ids are being transmitted (sender and receiver ids are properly handled though). It should also filter out most invalid rednet messages.

RemoteManagementService now properly purges outdated nonces. It also now is designed to operate behind RedNAT.

remoteManagementPocket now allows for seeing the configuration of a given computer and now also exposes the reboot option.